### PR TITLE
feat(executor): map and execute Claude CLI actions with file logging (TASK-081)

### DIFF
--- a/src/core/command-runner.service.ts
+++ b/src/core/command-runner.service.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@nestjs/common';
+import { spawn } from 'child_process';
+
+export type RunResult = {
+  code: number;
+};
+
+export type RunOptions = {
+  cwd?: string;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+  onStdoutLine?: (line: string) => void;
+  onStderrLine?: (line: string) => void;
+  signal?: AbortSignal;
+};
+
+@Injectable()
+export class CommandRunnerService {
+  async runShell(command: string, args: string[] = [], options?: RunOptions): Promise<RunResult> {
+    return new Promise<RunResult>((resolve, reject) => {
+      const child = spawn(command, args, {
+        cwd: options?.cwd ?? process.cwd(),
+        env: { ...process.env, ...(options?.env ?? {}) },
+        shell: false,
+      });
+
+      let stdoutBuffer = '';
+      let stderrBuffer = '';
+
+      const flushLines = (buffer: string, emit: (line: string) => void): string => {
+        const lines = buffer.split(/\r?\n/);
+        for (let i = 0; i < lines.length - 1; i++) emit(lines[i]!);
+        return lines.length > 0 ? lines[lines.length - 1]! : '';
+      };
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdoutBuffer += chunk.toString('utf-8');
+        if (options?.onStdoutLine) {
+          stdoutBuffer = flushLines(stdoutBuffer, options.onStdoutLine);
+        }
+      });
+
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderrBuffer += chunk.toString('utf-8');
+        if (options?.onStderrLine) {
+          stderrBuffer = flushLines(stderrBuffer, options.onStderrLine);
+        }
+      });
+
+      const onExit = (code: number | null) => {
+        // flush remaining partial lines
+        if (options?.onStdoutLine && stdoutBuffer.length > 0) options.onStdoutLine(stdoutBuffer);
+        if (options?.onStderrLine && stderrBuffer.length > 0) options.onStderrLine(stderrBuffer);
+        resolve({ code: code ?? -1 });
+      };
+
+      child.on('error', (err) => reject(err));
+      child.on('close', onExit);
+
+      if (options?.signal) {
+        options.signal.addEventListener('abort', () => {
+          try { child.kill('SIGTERM'); } catch {}
+        });
+      }
+
+      if (options?.timeoutMs && options.timeoutMs > 0) {
+        setTimeout(() => {
+          try { child.kill('SIGKILL'); } catch {}
+          reject(new Error('Process timeout exceeded'));
+        }, options.timeoutMs);
+      }
+    });
+  }
+
+  async runClaudeWithInput(params: {
+    action: 'task' | 'query' | 'continue' | 'resume' | 'commit';
+    prompt?: string;
+    cwd?: string;
+    env?: Record<string, string>;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+    onStdoutLine?: (line: string) => void;
+    onStderrLine?: (line: string) => void;
+  }): Promise<RunResult> {
+    const { action, prompt, cwd, env, timeoutMs, signal, onStdoutLine, onStderrLine } = params;
+
+    const cli = 'claude';
+    const args: string[] = [];
+
+    switch (action) {
+      case 'task':
+        args.push('task');
+        if (prompt) args.push('-p', prompt);
+        break;
+      case 'query':
+        args.push('query');
+        if (prompt) args.push('-p', prompt);
+        break;
+      case 'continue':
+        args.push('-c');
+        if (prompt) args.push('-p', prompt);
+        break;
+      case 'resume':
+        args.push('-r');
+        if (prompt) args.push('-p', prompt);
+        break;
+      case 'commit':
+        args.push('commit');
+        break;
+      default:
+        throw new Error(`Unsupported Claude action: ${action}`);
+    }
+
+    return this.runShell(cli, args, { cwd, env, timeoutMs, signal, onStdoutLine, onStderrLine });
+  }
+}
+
+

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { ExecutionStateService } from './execution-state.service';
 import { WorkflowExecutorService } from './workflow-executor.service';
 import { LoggerContextService } from './logger-context.service';
+import { FileLoggerService } from './file-logger.service';
+import { CommandRunnerService } from './command-runner.service';
 
 @Module({
   imports: [],
   controllers: [],
-  providers: [ExecutionStateService, WorkflowExecutorService, LoggerContextService],
-  exports: [ExecutionStateService, WorkflowExecutorService, LoggerContextService],
+  providers: [ExecutionStateService, WorkflowExecutorService, LoggerContextService, FileLoggerService, CommandRunnerService],
+  exports: [ExecutionStateService, WorkflowExecutorService, LoggerContextService, FileLoggerService, CommandRunnerService],
 })
 export class CoreModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     "checkJs": false
   },
   "include": [
-    "src/**/*",
+    "src/**/*.ts",
     "test/**/*"
   ],
   "exclude": [


### PR DESCRIPTION
### ✨ 요약 (What)
- **Executor에 Claude CLI 액션 매핑/실행 로직 구현**: `task|query|-c|-r|commit` 옵션 처리
- **파일 로그(JSONL) 연동**: stdout/stderr 라인 단위 캡처 → `FileLoggerService`로 기록
- **재시도/백오프/타임아웃 연동**: `policy.retry`/`policy.timeout` 반영
- **기본 run 실행 경로도 안전하게 처리**: 공백/빈 바이너리 가드, 타임아웃 적용

### 🧭 배경/이유 (Why)
- TASK-080에서 DSL 스키마가 확장됨에 따라, **실제 실행 경로**가 필요합니다.
- CLI(`claude`) 호출과 실행 로그를 남겨, 이후 `logs/status` 개선(TASK-083)과 대시보드 연동 기반 마련.

### 🛠️ 변경사항 (Changes)
- `src/core/command-runner.service.ts`: 외부 프로세스 실행 유틸 추가(spawn 기반, 라인 단위 캡처)
- `src/core/workflow-executor.service.ts`: 
  - `claude` 액션 매핑/실행 구현
  - `FileLoggerService` 연동(워크플로/스테이지/스텝 시작/완료/실패 기록)
  - `run` 커맨드 안전 실행 처리
- `src/core/core.module.ts`: DI 등록 (`FileLoggerService`, `CommandRunnerService`)
- `tsconfig.json`: 빌드시 Next.js TSX 제외(`src/**/*.ts`)로 Nest 빌드 타입 충돌 제거

### ✅ 테스트 (How verified)
- `npm run build` 정상
- `npm test` 전체 통과: 7 passed / 0 failed
- 유닛 테스트에서 `CommandRunnerService`/`FileLoggerService`를 주입하여 Executor 초기화 확인

### 🎯 영향도/리스크 (Impact/Risks)
- 외부 프로세스 실행: 환경에 `claude` 명령이 없을 경우 런타임 오류 가능 → 이후 설치 가이드/TASK-084에서 문서화 예정
- 로그 볼륨 증가 가능성: stdout/stderr 라인 단위 기록 → `logs` 필터링/레벨 제어 개선은 TASK-083에 위임

### 🚀 롤아웃/롤백
- 롤아웃: 기본 비파괴 변경; CLI가 없으면 실패하므로 안전
- 롤백: 이 PR revert로 이전 상태 복구 가능

### ☑️ 체크리스트
- [x] 액션별 CLI 인자 정확성 (`task|query|-c|-r|commit`)
- [x] stdout/stderr 파일 로그 기록(runId 기준)
- [x] `policy.retry`/백오프/타임아웃 적용
- [x] 테스트/빌드 녹색 상태
- [x] docs 갱신은 머지 후 진행(규칙 준수)

### 🔗 관련 태스크
- TASK-081 (본 PR)
- TASK-080 (의존성) / TASK-083,084 (후속)
