### PR TITLE
feat(cli): logs/status 정비 (TASK-083)

### DIFF
--- a/src/cli/commands/status.command.ts
+++ b/src/cli/commands/status.command.ts
@@ -1,12 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { Command, CommandRunner, Option } from 'nest-commander';
+import * as fs from 'fs';
+import { FileLoggerService, FileLogEntry, FileLogLevel } from '../../core/file-logger.service';
 
 @Injectable()
 @Command({
   name: 'status',
-  description: 'Show Claude workflow status',
+  description: 'Show Claude workflow status inferred from latest run logs',
 })
 export class StatusCommand extends CommandRunner {
+  constructor(private readonly fileLogger: FileLoggerService) {
+    super();
+  }
   @Option({
     flags: '-w, --workflow <id>',
     description: 'Show status for specific workflow ID',
@@ -31,29 +36,107 @@ export class StatusCommand extends CommandRunner {
     return val;
   }
 
+  @Option({
+    flags: '-r, --run <id>',
+    description: 'Run ID to infer status from (defaults to latest)'
+  })
+  parseRun(val: string): string {
+    return val;
+  }
+
+  private readAllEntries(filePath: string): FileLogEntry[] {
+    try {
+      const content = fs.readFileSync(filePath, { encoding: 'utf-8' });
+      return content
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map(line => { try { return JSON.parse(line); } catch { return undefined as any; } })
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  private inferStatus(entries: FileLogEntry[], opts?: { workflow?: string }): { workflow?: string; status: 'running' | 'completed' | 'failed' | 'unknown'; progress: number; startedAt?: string; updatedAt?: string; lastLevel?: FileLogLevel; lastMessage?: string } {
+    const filtered = opts?.workflow ? entries.filter(e => e.workflow === opts.workflow) : entries;
+    if (filtered.length === 0) {
+      return { status: 'unknown', progress: 0 };
+    }
+    // Determine workflow name and steps
+    const workflow = filtered.find(e => !!e.workflow)?.workflow;
+    const stepStarts = new Set(filtered.filter(e => e.message === 'Step started').map(e => `${e.stage}:${e.step}`));
+    const stepCompletes = new Set(filtered.filter(e => e.message === 'Step completed').map(e => `${e.stage}:${e.step}`));
+    const stepFails = filtered.filter(e => (e.level === 'error' || (e.message || '').toLowerCase().startsWith('step failed')));
+    const wfFailed = filtered.some(e => e.level === 'error' && (e.message || '').toLowerCase().includes('workflow failed'));
+    const wfCompleted = filtered.some(e => (e.message || '').toLowerCase().includes('workflow completed'));
+    let status: 'running' | 'completed' | 'failed' | 'unknown' = 'running';
+    if (wfCompleted) status = 'completed';
+    else if (wfFailed || stepFails.length > 0) status = 'failed';
+
+    let total = stepStarts.size;
+    if (total === 0) {
+      // fallback to unique seen steps in entries
+      const uniqueSteps = new Set(filtered.filter(e => e.step).map(e => `${e.stage}:${e.step}`));
+      total = uniqueSteps.size;
+    }
+    const done = stepCompletes.size;
+    const progress = total > 0 ? Math.round((done / total) * 100) : (status === 'completed' ? 100 : 0);
+    const last = filtered[filtered.length - 1];
+    const startedAt = filtered.find(e => (e.message || '').toLowerCase().includes('workflow started'))?.timestamp;
+    const result = {
+      workflow,
+      status,
+      progress,
+      startedAt,
+      updatedAt: last?.timestamp,
+      lastLevel: last?.level,
+      lastMessage: last?.message,
+    };
+    return result;
+  }
+
   async run(passedParams: string[], options?: Record<string, any>): Promise<void> {
     console.log('📊 Claude Workflow Status');
     console.log('========================');
 
-    if (options?.workflow) {
-      console.log(`Workflow ID: ${options.workflow}`);
-      // TODO: Implement specific workflow status logic
-      console.log('Status: Running');
-      console.log('Progress: 75%');
-      console.log('Started: 2024-01-15 10:30:00');
-    } else if (options?.all) {
-      console.log('All Workflows:');
-      // TODO: Implement all workflows status logic
-      console.log('  - workflow-001: Completed');
-      console.log('  - workflow-002: Running');
-      console.log('  - workflow-003: Pending');
-    } else {
-      console.log('Recent Workflows:');
-      // TODO: Implement recent workflows status logic
-      console.log('  - workflow-001: Completed (2 minutes ago)');
-      console.log('  - workflow-002: Running (5 minutes ago)');
+    const runId: string | undefined = options?.run;
+    const filePath = this.fileLogger.getLogFilePath(runId);
+    if (!filePath) {
+      console.log(runId ? `No log file found for run: ${runId}` : 'No logs found');
+      return;
     }
 
+    const entries = this.readAllEntries(filePath);
+    if (options?.all) {
+      // Group by workflow and infer each
+      const byWf = new Map<string, FileLogEntry[]>();
+      for (const e of entries) {
+        const key = e.workflow || 'unknown';
+        const arr = byWf.get(key) || [];
+        arr.push(e);
+        byWf.set(key, arr);
+      }
+      for (const [wf, list] of byWf.entries()) {
+        const s = this.inferStatus(list, { workflow: wf !== 'unknown' ? wf : undefined });
+        console.log(`- ${wf}: ${s.status} (${s.progress}%)`);
+      }
+      console.log(`Output format: ${options?.format || 'table'}`);
+      return;
+    }
+
+    const status = this.inferStatus(entries, { workflow: options?.workflow });
+    if ((options?.format || 'table') === 'json') {
+      console.log(JSON.stringify(status));
+      return;
+    }
+    if (status.workflow) console.log(`Workflow: ${status.workflow}`);
+    console.log(`Status: ${status.status}`);
+    console.log(`Progress: ${status.progress}%`);
+    if (status.startedAt) console.log(`Started: ${status.startedAt}`);
+    if (status.updatedAt) console.log(`Updated: ${status.updatedAt}`);
+    if (status.lastLevel && status.lastMessage) {
+      console.log(`Last: [${String(status.lastLevel).toUpperCase()}] ${status.lastMessage}`);
+    }
     console.log(`Output format: ${options?.format || 'table'}`);
   }
 }

--- a/src/core/workflow-executor.service.ts
+++ b/src/core/workflow-executor.service.ts
@@ -34,6 +34,7 @@ export class WorkflowExecutorService {
         await this.executeStage(workflow, stageId, options);
       }
       this.state.setWorkflowStatus(WorkflowExecutionStatus.COMPLETED);
+      this.fileLogger.write('info', 'Workflow completed', { workflow: workflow.name });
     } catch (error) {
       this.state.setWorkflowStatus(WorkflowExecutionStatus.FAILED);
       this.fileLogger.write('error', 'Workflow failed', { workflow: workflow.name, meta: { error: (error as Error)?.message } });


### PR DESCRIPTION
### ✨ 요약 (What)
- **CLI logs/status 정비 (TASK-083)**
- `logs`: JSONL 기반 실제 로그 읽기/필터링/팔로우 구현
- `status`: run 로그로 워크플로 상태/진행률 추정 구현
- `executor`: 최종 완료 마커(`Workflow completed`) 기록 추가

### 🧭 배경/이유 (Why)
- 스펙 상 runId 기반 상태 추정 고도화 및 tail 기본값/필터 개선 필요
- 운영중 실행 상태 확인과 디버깅을 위해 실사용 가능한 `logs`/`status`가 필요

### 🛠️ 변경사항 (Changes)
- `src/cli/commands/logs.command.ts`: JSONL 파싱, `-n/--lines` 기본 50, `--level`, `--since`, `-f/--follow`, `-r/--run` 지원
- `src/cli/commands/status.command.ts`: `--run`, `--format json`, `--all` 지원, 로그 기반 상태 추정(완료/실패/진행률)
- `src/core/workflow-executor.service.ts`: 최종 완료 로그(`Workflow completed`) 기록

### 🖼️ 스크린샷/로그
```bash
npm test
# 모든 테스트 그린
```

### ✅ 테스트 (How verified)
- 단위 테스트 전체 실행: 그린
- 수동 검증: 더미 로그 파일에서 `logs --level`, `--since`, `--follow` 확인

### 🎯 영향도/리스크
- 기존 CLI 인터페이스와 호환성 유지(옵션 확장)
- 로그 파일(JSONL) 접근 경로는 `FileLoggerService`의 규칙과 일치

### 🚀 롤아웃/롤백
- 롤아웃: 머지 후 배포 없음, 다음 릴리스에 포함
- 롤백: 해당 커밋 되돌리기

### ☑️ 체크리스트
- [x] 빌드/테스트 그린
- [x] 프로젝트 규칙 준수(포트/문서 정책 등)
- [x] 보안 이슈 없음

### 🔗 참고
- DEVELOPMENT_TASKS: TASK-083 완료기준 반영
