### PR TITLE
feat(github): optional integration with mode fallback (TASK-090)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,21 @@ npm run format
 npm run build
 ```
 
+### 🔧 GitHub 통합 옵션
+
+- 환경변수
+  - `USE_GITHUB`: `true|false` (기본 true) — 전체 GitHub 통합 사용 여부
+  - `GITHUB_MODE`: `auto|cli|token|manual` (기본 `auto`) — 사용 모드 지정
+  - `GITHUB_TOKEN`: token 모드에서 사용되는 GitHub Personal Access Token
+  - `GITHUB_API_BASE`: GitHub Enterprise 등 API base override (옵션)
+
+- 설정 파일(`claude-auto-worker.config.yaml`) 예시
+```yaml
+github:
+  enabled: true
+  mode: auto # or cli|token|manual
+```
+
 ## 📄 라이선스
 
 이 프로젝트는 [MIT 라이선스](LICENSE) 하에 배포됩니다.

--- a/docs/project/DEVELOPMENT_TASKS.md
+++ b/docs/project/DEVELOPMENT_TASKS.md
@@ -130,6 +130,7 @@
 - (선택) TASK-023: Usage Limit 감지/백오프
  - TASK-080: DSL 확장(Claude CLI 액션 스키마/검증)
  - TASK-081: Executor에 Claude CLI 액션 매핑/실행(파일 로그 연동)
+ - TASK-090: GitHub 통합 모드 옵션화/폴백(gh CLI → token → manual)
 
 ### Next (단기)
 - TASK-027: 대시보드 실행 현황/진행률/ETA
@@ -553,6 +554,16 @@
   - [ ] 자동 복구 시도
   - [ ] 수동 개입 필요 시나리오
   - [ ] 에러 로깅 및 알림
+
+#### TASK-090: GitHub 통합 모드 옵션화 및 폴백
+- **예상 시간**: 6시간
+- **담당 영역**: DevEx/통합
+- **의존성**: 없음
+- **완료 기준**:
+  - [ ] 설정에 `github.enabled`, `github.mode` 추가(환경변수 `USE_GITHUB`, `GITHUB_MODE` 연동)
+  - [ ] 모드 자동 감지 및 3단계 폴백: gh CLI(로그인) → 토큰(`GITHUB_TOKEN`) → manual(compare URL)
+  - [ ] 최소 단위 테스트: 모드 감지, `enabled=false` 시 강제 manual 반환
+  - [ ] 문서(README/설정 템플릿) 안내 초안
 
 ---
 

--- a/src/config/project-config.service.ts
+++ b/src/config/project-config.service.ts
@@ -19,6 +19,10 @@ export interface ProjectConfig {
   dashboard?: {
     enabled?: boolean;
   };
+  github?: {
+    enabled?: boolean; // 전체 GitHub 통합 사용 여부
+    mode?: 'auto' | 'cli' | 'token' | 'manual'; // 선택 모드
+  };
   environments?: Record<string, Partial<ProjectConfig>>;
 }
 
@@ -36,6 +40,10 @@ function createDefaultConfig(): ProjectConfig {
     dashboard: {
       enabled: true,
     },
+    github: {
+      enabled: process.env.USE_GITHUB ? /^(1|true|yes)$/i.test(process.env.USE_GITHUB) : true,
+      mode: (process.env.GITHUB_MODE as any) || 'auto',
+    },
   };
 }
 
@@ -51,6 +59,10 @@ const schema = Joi.object<ProjectConfig>({
   }).default(),
   dashboard: Joi.object({
     enabled: Joi.boolean().default(true),
+  }).default(),
+  github: Joi.object({
+    enabled: Joi.boolean().default(true),
+    mode: Joi.string().valid('auto', 'cli', 'token', 'manual').default('auto'),
   }).default(),
   environments: Joi.object()
     .pattern(/^[a-zA-Z0-9_-]+$/, Joi.object({}).unknown(true))

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -3,6 +3,7 @@ import { LoggingConfigService } from '../config/logging-config.service';
 import { ProjectConfigService } from '../config/project-config.service';
 import { GitService } from '../git/git.service';
 import { GIT_BASE_DIR } from '../git/git.tokens';
+import { GithubIntegrationService } from '../git/github-integration.service';
 import { ParserModule } from '../parser/parser.module';
 import { CommandRunnerService } from './command-runner.service';
 import { EnhancedLogParserService } from './enhanced-log-parser.service';
@@ -25,6 +26,7 @@ import { WorkflowStateTrackerService } from './workflow-state-tracker.service';
     LoggingConfigService,
     ProjectConfigService,
     GitService,
+    GithubIntegrationService,
     {
       provide: GIT_BASE_DIR,
       useFactory: () => process.env.GIT_BASE_DIR || process.cwd(),

--- a/src/git/github-integration.service.ts
+++ b/src/git/github-integration.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@nestjs/common';
+import { ProjectConfigService } from '../config/project-config.service';
+import { CommandRunnerService } from '../core/command-runner.service';
+
+export type GithubMode = 'cli' | 'token' | 'manual';
+
+export interface CreatePrParams {
+  owner: string;
+  repo: string;
+  base: string;
+  head: string;
+  title: string;
+  body?: string;
+}
+
+@Injectable()
+export class GithubIntegrationService {
+  constructor(private readonly commandRunner: CommandRunnerService, private readonly projectConfig: ProjectConfigService) {}
+
+  async detectMode(preferred?: GithubMode | 'auto'): Promise<GithubMode> {
+    const mode = preferred === 'auto' || !preferred ? undefined : preferred;
+    if (mode === 'cli') {
+      if (await this.isGhUsable()) return 'cli';
+      return (await this.hasToken()) ? 'token' : 'manual';
+    }
+    if (mode === 'token') return (await this.hasToken()) ? 'token' : (await this.isGhUsable()) ? 'cli' : 'manual';
+    if (mode === 'manual') return 'manual';
+
+    // auto
+    if (await this.isGhUsable()) return 'cli';
+    if (await this.hasToken()) return 'token';
+    return 'manual';
+  }
+
+  private async isGhUsable(): Promise<boolean> {
+    const v = await this.commandRunner.runShell('gh', ['--version']);
+    if (v.code !== 0) return false;
+    const auth = await this.commandRunner.runShell('gh', ['auth', 'status']);
+    return auth.code === 0;
+  }
+
+  private async hasToken(): Promise<boolean> {
+    const token = process.env.GITHUB_TOKEN;
+    return !!(token && token.trim().length > 0);
+  }
+
+  async createPr(params: CreatePrParams, preferred?: GithubMode | 'auto'): Promise<{ mode: GithubMode; url: string }> {
+    const cfg = this.projectConfig.getResolvedConfig();
+    if (cfg.github?.enabled === false) {
+      return { mode: 'manual', url: this.compareUrl(params) };
+    }
+    const mode = await this.detectMode(preferred ?? (cfg.github?.mode as any) ?? 'auto');
+    if (mode === 'cli') {
+      const args = ['pr', 'create', '--title', params.title, '--base', params.base, '--head', params.head];
+      if (params.body) {
+        args.push('--body', params.body);
+      }
+      const res = await this.commandRunner.runShell('gh', args);
+      if (res.code === 0) {
+        // gh prints URL on success; best-effort parse last non-empty line
+        const out = String((res as any).stdout || '').trim().split('\n').filter(Boolean).pop() || '';
+        return { mode, url: out || this.compareUrl(params) };
+      }
+      // fallback
+      return { mode: 'manual', url: this.compareUrl(params) };
+    }
+
+    if (mode === 'token') {
+      const apiBase = process.env.GITHUB_API_BASE || 'https://api.github.com';
+      const token = process.env.GITHUB_TOKEN as string;
+      const url = `${apiBase}/repos/${params.owner}/${params.repo}/pulls`;
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/vnd.github+json',
+        },
+        body: JSON.stringify({
+          title: params.title,
+          head: params.head,
+          base: params.base,
+          body: params.body,
+        }),
+      } as any);
+      if (resp.ok) {
+        const data = await resp.json() as any;
+        return { mode, url: data.html_url };
+      }
+      return { mode: 'manual', url: this.compareUrl(params) };
+    }
+
+    return { mode: 'manual', url: this.compareUrl(params) };
+  }
+
+  private compareUrl(params: CreatePrParams): string {
+    return `https://github.com/${params.owner}/${params.repo}/compare/${params.base}...${params.head}?expand=1`;
+  }
+}
+
+

--- a/src/test/unit/github-integration.service.spec.ts
+++ b/src/test/unit/github-integration.service.spec.ts
@@ -1,0 +1,100 @@
+import { Test } from '@nestjs/testing';
+import { ProjectConfigService } from '../../config/project-config.service';
+import { CommandRunnerService } from '../../core/command-runner.service';
+import { GithubIntegrationService } from '../../git/github-integration.service';
+
+describe('GithubIntegrationService (unit)', () => {
+  it('should detect cli mode when gh is available and authed', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        GithubIntegrationService,
+        {
+          provide: ProjectConfigService,
+          useValue: { getResolvedConfig: () => ({ github: { enabled: true, mode: 'auto' } }) },
+        },
+        {
+          provide: CommandRunnerService,
+          useValue: {
+            runShell: jest.fn()
+              .mockResolvedValueOnce({ code: 0 }) // gh --version
+              .mockResolvedValueOnce({ code: 0 }), // gh auth status
+          },
+        },
+      ],
+    }).compile();
+
+    const svc = moduleRef.get(GithubIntegrationService);
+    await expect(svc.detectMode('auto')).resolves.toBe('cli');
+  });
+
+  it('should fallback to token mode when gh is not available but token exists', async () => {
+    const prev = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'x';
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        GithubIntegrationService,
+        {
+          provide: ProjectConfigService,
+          useValue: { getResolvedConfig: () => ({ github: { enabled: true, mode: 'auto' } }) },
+        },
+        {
+          provide: CommandRunnerService,
+          useValue: {
+            runShell: jest.fn().mockResolvedValue({ code: 1 }),
+          },
+        },
+      ],
+    }).compile();
+
+    const svc = moduleRef.get(GithubIntegrationService);
+    await expect(svc.detectMode('auto')).resolves.toBe('token');
+    if (prev === undefined) delete process.env.GITHUB_TOKEN; else process.env.GITHUB_TOKEN = prev;
+  });
+
+  it('should fall back to manual when neither gh nor token is available', async () => {
+    const prev = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        GithubIntegrationService,
+        {
+          provide: ProjectConfigService,
+          useValue: { getResolvedConfig: () => ({ github: { enabled: true, mode: 'auto' } }) },
+        },
+        {
+          provide: CommandRunnerService,
+          useValue: {
+            runShell: jest.fn().mockResolvedValue({ code: 1 }),
+          },
+        },
+      ],
+    }).compile();
+
+    const svc = moduleRef.get(GithubIntegrationService);
+    await expect(svc.detectMode('auto')).resolves.toBe('manual');
+    if (prev !== undefined) process.env.GITHUB_TOKEN = prev;
+  });
+
+  it('should force manual when github.enabled=false', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        GithubIntegrationService,
+        {
+          provide: ProjectConfigService,
+          useValue: { getResolvedConfig: () => ({ github: { enabled: false, mode: 'cli' } }) },
+        },
+        {
+          provide: CommandRunnerService,
+          useValue: { runShell: jest.fn().mockResolvedValue({ code: 0 }) },
+        },
+      ],
+    }).compile();
+
+    const svc = moduleRef.get(GithubIntegrationService);
+    const out = await svc.createPr({ owner: 'o', repo: 'r', base: 'main', head: 'feat', title: 't' }, 'cli');
+    expect(out.mode).toBe('manual');
+    expect(out.url).toContain('/compare/');
+  });
+});
+
+


### PR DESCRIPTION
### ✨ 요약 (What)
- GitHub 통합을 옵션화하고, 모드 자동 감지/폴백(gh CLI → 토큰 → manual)을 도입했습니다.
- 설정 파일과 환경변수로 사용자가 GitHub 사용 여부와 방식을 제어할 수 있습니다.

### 🧭 배경/이유 (Why)
- 일부 환경에서는 gh CLI가 없거나 미인증일 수 있고, 토큰 제공도 선택 사항입니다.
- 사용자 환경을 존중하며, 깔끔한 폴백 경로를 제공해 워크플로우를 끊기지 않게 합니다.

### 🛠 변경사항 (Changes)
- src/config/project-config.service.ts: github.enabled, github.mode 추가 (env: USE_GITHUB, GITHUB_MODE)
- src/git/github-integration.service.ts: 모드 자동 감지 및 PR 생성(gh/token/manual) 지원
- src/core/core.module.ts: GithubIntegrationService 등록
- src/test/unit/github-integration.service.spec.ts: 모드 감지/강제 manual 테스트 추가
- docs/project/DEVELOPMENT_TASKS.md: TASK-090 추가

### ⚙️ 설정/옵션 (Config)
- github.enabled: true/false (기본 true; env USE_GITHUB로 제어)
- github.mode: auto | cli | token | manual (기본 auto; env GITHUB_MODE)
- 토큰 사용 시: GITHUB_TOKEN 필요

### ✅ 테스트 (How verified)
- 빌드/유닛/CLI/e2e 테스트 통과
- 단위 테스트로 다음 시나리오 검증: gh 사용 가능, gh 불가+토큰 있음, gh/토큰 모두 불가, enabled=false 강제 manual

### 🎯 영향도/리스크
- 런타임 기본 동작은 manual 경로로도 안전히 수행
- gh/token 경로 실패 시 자동으로 manual(비교 링크)로 폴백

### ☑️ 체크리스트
- [x] 빌드/테스트 그린
- [x] 설정/환경변수 문서화 (본문 포함)
- [x] 기존 워크플로우와 호환성 유지

### 🔗 참고 링크
- 관련 PR: https://github.com/0113bernoyoun/claude-auto-worker/pull/27